### PR TITLE
feat: 支持从指定页码或since_id开始下载

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,7 @@ MigrationBackup/
 FodyWeavers.xsd
 /Demos/Demos.Algorithm/Demos.Algorithm.Toolbox.MaojiaExamine/CameraDevices.cs
 /Demos/Demos.Algorithm/Demo.Algorithm.Toolbox.Maojia/Demo.Algorithm.Toolbox.Maojia.csproj
+
+
+/WeiboAlbumDownloader/DownLoad
+Settings.json

--- a/WeiboAlbumDownloader/Helpers/HttpHelper.cs
+++ b/WeiboAlbumDownloader/Helpers/HttpHelper.cs
@@ -28,8 +28,8 @@ namespace WeiboAlbumDownloader.Helpers
             string responseBody = null;
             try
             {
-                logAction?.Invoke($"[Request URL]: {url}", MessageEnum.Info);
-                logAction?.Invoke($"[Request Cookie]: {cookie}", MessageEnum.Info);
+                //logAction?.Invoke($"[Request URL]: {url}", MessageEnum.Info);
+                //logAction?.Invoke($"[Request Cookie]: {cookie}", MessageEnum.Info);
 
                 var handler = new HttpClientHandler()
                 {
@@ -66,7 +66,7 @@ namespace WeiboAlbumDownloader.Helpers
                 }
 
                 logAction?.Invoke($"[Response Status Code]: {response.StatusCode}", MessageEnum.Info);
-                logAction?.Invoke($"[Response Body]: {responseBody}", MessageEnum.Info);
+                //logAction?.Invoke($"[Response Body]: {responseBody}", MessageEnum.Info);
 
                 response.EnsureSuccessStatusCode();
 
@@ -114,7 +114,7 @@ namespace WeiboAlbumDownloader.Helpers
                 logAction?.Invoke($"[Request Failed]: URL: {url}", MessageEnum.Error);
                 if (responseBody != null)
                 {
-                    logAction?.Invoke($"[Failed Response Body]: {responseBody}", MessageEnum.Error);
+                    //logAction?.Invoke($"[Failed Response Body]: {responseBody}", MessageEnum.Error);
                 }
                 logAction?.Invoke($"[Exception]: {ex.ToString()}", MessageEnum.Error);
                 throw;

--- a/WeiboAlbumDownloader/Helpers/HttpHelper.cs
+++ b/WeiboAlbumDownloader/Helpers/HttpHelper.cs
@@ -23,10 +23,14 @@ namespace WeiboAlbumDownloader.Helpers
         /// <param name="url"></param>
         /// <param name="fileName">不为空的时候，表示存图</param>
         /// <returns></returns>
-        public static async Task<T> GetAsync<T>(string url, WeiboDataSource dataSource, string cookie, string fileName = "")
+        public static async Task<T> GetAsync<T>(string url, WeiboDataSource dataSource, string cookie, string fileName = "", Action<string, MessageEnum> logAction = null)
         {
+            string responseBody = null;
             try
             {
+                logAction?.Invoke($"[Request URL]: {url}", MessageEnum.Info);
+                logAction?.Invoke($"[Request Cookie]: {cookie}", MessageEnum.Info);
+
                 var handler = new HttpClientHandler()
                 {
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
@@ -36,11 +40,6 @@ namespace WeiboAlbumDownloader.Helpers
                 request.Headers.Add("Referer", "https://m.weibo.cn/");
                 if (string.IsNullOrEmpty(fileName))
                 {
-                    //request.Headers.Add("Host", "m.weibo.cn");
-                    //request.Headers.Add("Connection", "keep-alive");
-                    //request.Headers.Add("Pragma", "no-cache");
-                    //request.Headers.Add("Cache-Control", "no-cache");
-                    //request.Headers.Add("Sec-Ch-Ua-Platform", "\"Windows\"");
                     request.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36");
                     request.Headers.Add("Accept", "application/json, text/plain, */*");
                     request.Headers.Add("Accept-Encoding", "gzip, deflate, br");
@@ -49,16 +48,9 @@ namespace WeiboAlbumDownloader.Helpers
                 }
 
                 var response = await client.SendAsync(request);
-                response.EnsureSuccessStatusCode();
 
                 var contentEncoding = response.Content.Headers.ContentEncoding.ToString();
-                var contentType = response.Content.Headers.ContentType.ToString();
 
-                Debug.WriteLine("Content-Encoding: " + contentEncoding);
-                Debug.WriteLine("Content-Type: " + contentType);
-
-                string responseBody;
-                // 检查是否是压缩数据并手动解压
                 if (contentEncoding.Contains("gzip"))
                 {
                     using (var stream = await response.Content.ReadAsStreamAsync())
@@ -66,29 +58,43 @@ namespace WeiboAlbumDownloader.Helpers
                     using (var reader = new StreamReader(decompressedStream))
                     {
                         responseBody = await reader.ReadToEndAsync();
-                        Debug.WriteLine(responseBody);  // 打印解压后的内容
                     }
                 }
                 else
                 {
-                    // 如果没有压缩，直接读取
                     responseBody = await response.Content.ReadAsStringAsync();
-                    Debug.WriteLine(responseBody);  // 打印返回的内容
                 }
 
+                logAction?.Invoke($"[Response Status Code]: {response.StatusCode}", MessageEnum.Info);
+                logAction?.Invoke($"[Response Body]: {responseBody}", MessageEnum.Info);
+
+                response.EnsureSuccessStatusCode();
 
                 if (!string.IsNullOrEmpty(fileName))
                 {
-                    var invalidChar = Path.GetInvalidFileNameChars();
-                    var newFileName = invalidChar.Aggregate(Path.GetFileName(fileName), (o, r) => (o.Replace(r.ToString(), string.Empty)));
+                    string directory = Path.GetDirectoryName(fileName);
+                    string fileNameOnly = Path.GetFileName(fileName);
 
-                    if (newFileName.Length > 200)
-                        newFileName = GetUniqueFileName(newFileName.Substring(0, 200) + Path.GetExtension(newFileName));
+                    var invalidChar = Path.GetInvalidFileNameChars();
+                    var cleanedFileNameOnly = invalidChar.Aggregate(fileNameOnly, (o, r) => (o.Replace(r.ToString(), string.Empty)));
+
+                    string finalFullPath;
+                    if (cleanedFileNameOnly.Length > 200)
+                    {
+                        // Truncate the file name part, then recombine with the original directory
+                        string truncatedFileName = cleanedFileNameOnly.Substring(0, 200) + Path.GetExtension(cleanedFileNameOnly);
+                        finalFullPath = Path.Combine(directory, truncatedFileName);
+                    }
                     else
-                        newFileName = GetUniqueFileName(fileName);
+                    {
+                        // Recombine the original directory with the cleaned file name
+                        finalFullPath = Path.Combine(directory, cleanedFileNameOnly);
+                    }
+
+                    string uniquePath = GetUniqueFileName(finalFullPath);
 
                     var stream = response.Content.ReadAsStream();
-                    FileStream lxFS = File.Create(newFileName);
+                    FileStream lxFS = File.Create(uniquePath);
                     await stream.CopyToAsync(lxFS);
                     lxFS.Close();
                     lxFS.Dispose();
@@ -103,8 +109,14 @@ namespace WeiboAlbumDownloader.Helpers
                 else
                     return JsonConvert.DeserializeObject<T>(responseBody);
             }
-            catch
+            catch (Exception ex)
             {
+                logAction?.Invoke($"[Request Failed]: URL: {url}", MessageEnum.Error);
+                if (responseBody != null)
+                {
+                    logAction?.Invoke($"[Failed Response Body]: {responseBody}", MessageEnum.Error);
+                }
+                logAction?.Invoke($"[Exception]: {ex.ToString()}", MessageEnum.Error);
                 throw;
             }
         }

--- a/WeiboAlbumDownloader/MainWindow.xaml
+++ b/WeiboAlbumDownloader/MainWindow.xaml
@@ -33,13 +33,26 @@
         <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
-      <mica:TextBox
-        x:Name="TextBox_WeiboId"
-        Height="32"
-        Margin="8,0,0,0"
-        KeyUp="TextBox_WeiboId_KeyUp"
-        ToolTip="填写uid进行单用户下载或者uidList.txt进行批量下载"
-        Watermark="微博uid" />
+      <StackPanel Grid.Column="0" Margin="8,0,0,0">
+        <mica:TextBox
+          x:Name="TextBox_WeiboId"
+          Height="32"
+          KeyUp="TextBox_WeiboId_KeyUp"
+          ToolTip="填写uid进行单用户下载或者uidList.txt进行批量下载"
+          Watermark="微博uid" />
+        <Grid Margin="0,4,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="起始页码:" VerticalAlignment="Center"/>
+            <mica:TextBox Grid.Column="1" x:Name="TextBox_StartPage" Height="32" Margin="4,0,0,0" Watermark="可选"/>
+            <TextBlock Grid.Column="2" Text="起始SinceID:" VerticalAlignment="Center" Margin="8,0,0,0"/>
+            <mica:TextBox Grid.Column="3" x:Name="TextBox_StartSinceId" Height="32" Margin="4,0,0,0" Watermark="可选"/>
+        </Grid>
+      </StackPanel>
       <StackPanel Grid.Column="1" Orientation="Horizontal">
         <mica:Button
           Width="110"


### PR DESCRIPTION
- 在主界面添加了“起始页码”和“起始SinceID”输入框，允许用户从中断的位置继续下载。
- 增强了HttpHelper中的日志记录和异常处理，会记录详细的请求/响应信息，便于调试。
- 优化了下载逻辑，在连续获取到3个空页面后会自动停止，以防止无限循环。
- 修复了当文件路径过长时可能导致的保存失败问题。
- 更新了 .gitignore 文件，以排除下载目录和配置文件。

貌似解决了
#18
